### PR TITLE
Allow httplug ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "require": {
     "php": "^5.6 || ^7.0",
-    "php-http/httplug": "^1.0",
+    "php-http/httplug": "^1.0 || ^2.0",
     "php-http/message": "^1.0",
     "php-http/client-implementation": "^1.0",
     "php-http/discovery": "^1.0"


### PR DESCRIPTION
I've just tested Sparkpost using HTTPlug v2.0 and it works fine. This PR updates the composer dependencies to allow ^2.0 as well as ^1.0. Fixes #186.